### PR TITLE
fix access to the db in rakefile for AR >= 6.1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'pry-byebug'
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'pry-byebug'
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
@@ -73,6 +74,10 @@ db_namespace = namespace :db do
   private
 
   def db_path
-    ActiveRecord::Base.configurations['development']['database']
+    if ActiveRecord.version.to_s.to_f >= 6.1
+      ActiveRecord::Base.configurations.configs_for(env_name: 'development', name: 'primary').database
+    else
+      ActiveRecord::Base.configurations['development']['database']
+    end
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -73,7 +73,7 @@ db_namespace = namespace :db do
   private
 
   def db_path
-    if ActiveRecord.version.to_s.to_f >= 6.1
+    if ActiveRecord.version.to_s >= "6.1"
       ActiveRecord::Base.configurations.configs_for(env_name: 'development', name: 'primary').database
     else
       ActiveRecord::Base.configurations['development']['database']


### PR DESCRIPTION
**Quick fix for dev who have installed AR >= 6.1**

[Nadia](https://kitt.lewagon.com/alumni/nadiaauger) reported me that the boilerplate wasn't working on her computer.

After quick investigations, it appears that doing `ActiveRecord::Base.configurations['development']['database']` is decrecated since AR 6.1.

Even if the version in the `Gemfile.lock` is `activerecord (6.0.2.1)`, user who have installed AR >= 6.1 will encounter this error for each `rake db` commands (I installed AR 6.1.1 to reproduce the bug) 👇 

![Screenshot 2021-01-08 at 13 21 31](https://user-images.githubusercontent.com/25386941/104015319-b9e9c300-51b4-11eb-9819-64c2bb5d89cf.png)

